### PR TITLE
Remove cron from NoZebra

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     branches: [ "NoZebra" ]
   workflow_dispatch:
-  schedule:
-    - cron: "0 * * * *"
   
 jobs:
   build:


### PR DESCRIPTION
There's no need for a cron with my NoZebra branch as
1. It's experimental and only made as a joke (it shouldn't exist but still)
2. It has no real-world use (uninstall Zebra through Sileo)
3. The branch will NOT be synced with main